### PR TITLE
feat: add metadata object

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Note: This tap currently does not support incremental state.
 | files               | False    | None    | An array of csv file stream settings. |
 | csv_files_definition| False    | None    | A path to the JSON file holding an array of file settings. |
 | add_metadata_columns| False    | False   | When True, add the metadata columns (`_sdc_source_file`, `_sdc_source_file_mtime`, `_sdc_source_lineno`) to output. |
+| add_metadata_dict| False    | False   | When True, adds the metadata object (`source`, `time_extractes`) to output. |
 
 A full list of supported settings and capabilities is available by running: `tap-csv --about`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note: This tap currently does not support incremental state.
 | files               | False    | None    | An array of csv file stream settings. |
 | csv_files_definition| False    | None    | A path to the JSON file holding an array of file settings. |
 | add_metadata_columns| False    | False   | When True, add the metadata columns (`_sdc_source_file`, `_sdc_source_file_mtime`, `_sdc_source_lineno`) to output. |
-| add_metadata_dict| False    | False   | When True, adds the metadata object (`source`, `time_extractes`) to output. |
+| add_metadata_dict| False    | False   | When True, adds the metadata object (`source`, `time_extracted`) to output. |
 
 A full list of supported settings and capabilities is available by running: `tap-csv --about`
 

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -11,7 +11,7 @@ from singer_sdk.streams import Stream
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"
 SDC_SOURCE_LINENO_COLUMN = "_sdc_source_lineno"
 SDC_SOURCE_FILE_MTIME_COLUMN = "_sdc_source_file_mtime"
-
+METADATA_COLUMN = "metadata"
 
 class CSVStream(Stream):
     """Stream class for CSV streams."""
@@ -156,7 +156,7 @@ class CSVStream(Stream):
         # If enabled, add file's metadata to output
         if self.config.get("add_metadata_dict", False):
             header = [
-                metadata
+                METADATA_COLUMN
             ] + header
 
             properties.append(th.Property(metadata, th.Dict))

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -48,6 +48,10 @@ class CSVStream(Stream):
                 if self.config.get("add_metadata_columns", False):
                     row = [file_path, file_last_modified, file_lineno] + row
 
+                if self.config.get("add_metadata_dict", False):
+                    metadata_dict={"source": "dummy.csv", "time_extracted": "234"}
+                    row = [str(metadata_dict)] + row
+
                 yield dict(zip(self.header, row))
 
     def _get_recursive_file_paths(self, file_path: str) -> list:

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -159,7 +159,7 @@ class CSVStream(Stream):
                 METADATA_COLUMN,
             ] + header
 
-            properties.append(th.Property(metadata, th.Dict))
+            properties.append(th.Property(METADATA_COLUMN, th.ObjectType))
         # Cache header for future use
         self.header = header
 

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -159,7 +159,12 @@ class CSVStream(Stream):
                 METADATA_COLUMN,
             ] + header
 
-            properties.append(th.Property(METADATA_COLUMN, th.ObjectType))
+            t = ObjectType(
+                Property("source", StringType),
+                Property("time_extracted", StringType),
+                additional_properties=False,
+                )
+            properties.append(th.Property(METADATA_COLUMN, t))
         # Cache header for future use
         self.header = header
 

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -49,7 +49,7 @@ class CSVStream(Stream):
                     row = [file_path, file_last_modified, file_lineno] + row
 
                 if self.config.get("add_metadata_dict", False):
-                    metadata_dict={"source": "dummy.csv", "time_extracted": "234"}
+                    metadata_dict={"source": file_path, "time_extracted": datetime.utcnow()}
                     row = [metadata_dict] + row
 
                 yield dict(zip(self.header, row))

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -50,7 +50,7 @@ class CSVStream(Stream):
 
                 if self.config.get("add_metadata_dict", False):
                     metadata_dict={"source": "dummy.csv", "time_extracted": "234"}
-                    row = [str(metadata_dict)] + row
+                    row = [metadata_dict] + row
 
                 yield dict(zip(self.header, row))
 

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -159,9 +159,9 @@ class CSVStream(Stream):
                 METADATA_COLUMN,
             ] + header
 
-            t = ObjectType(
-                Property("source", StringType),
-                Property("time_extracted", StringType),
+            t = th.ObjectType(
+                Property("source", th.StringType),
+                Property("time_extracted", th.StringType),
                 additional_properties=False,
                 )
             properties.append(th.Property(METADATA_COLUMN, t))

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -3,7 +3,7 @@
 import csv
 import os
 from datetime import datetime, timezone
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Dict
 
 from singer_sdk import typing as th
 from singer_sdk.streams import Stream
@@ -152,7 +152,14 @@ class CSVStream(Stream):
                 th.Property(SDC_SOURCE_FILE_MTIME_COLUMN, th.DateTimeType)
             )
             properties.append(th.Property(SDC_SOURCE_LINENO_COLUMN, th.IntegerType))
+  
+        # If enabled, add file's metadata to output
+        if self.config.get("add_metadata_dict", False):
+            header = [
+                metadata
+            ] + header
 
+            properties.append(th.Property(metadata, th.Dict))
         # Cache header for future use
         self.header = header
 

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -156,7 +156,7 @@ class CSVStream(Stream):
         # If enabled, add file's metadata to output
         if self.config.get("add_metadata_dict", False):
             header = [
-                METADATA_COLUMN
+                METADATA_COLUMN,
             ] + header
 
             properties.append(th.Property(metadata, th.Dict))

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -160,8 +160,8 @@ class CSVStream(Stream):
             ] + header
 
             t = th.ObjectType(
-                Property("source", th.StringType),
-                Property("time_extracted", th.StringType),
+                th.Property("source", th.StringType),
+                th.Property("time_extracted", th.StringType),
                 additional_properties=False,
                 )
             properties.append(th.Property(METADATA_COLUMN, t))

--- a/tap_csv/tap.py
+++ b/tap_csv/tap.py
@@ -53,6 +53,15 @@ class TapCSV(Tap):
                 "`_sdc_source_file_mtime`, `_sdc_source_lineno`) to output."
             ),
         ),
+        th.Property(
+            "add_metadata_dict",
+            th.BooleanType,
+            required=False,
+            default=False,
+            description=(
+                "When True, adds basic metadata as dict"
+            ),
+        ),
     ).to_dict()
 
     @classproperty


### PR DESCRIPTION
This PR adds a metadata object with "source" and "time_extracted" keys to to the output.

This is useful for the https://github.com/MeltanoLabs/map-gpt-embeddings/ mapper that does require an object to be passed into. 

Also, objects seem more versatile than mere columns (as used in the default meta data structure in tap-csv) as the current inline mappings capability seems to only allow to flatten an object into multiple columns, but not the reverse.