### PR TITLE
perf: Cache CSV stream schema 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-csv"
-version = "1.1.0"
+version = "1.2.0"
 description = "Singer tap for CSV, built with the Meltano SDK for Singer Taps."
 authors = ["Pat Nadolny"]
 keywords = [

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -28,6 +28,7 @@ class CSVStream(Stream):
         """Init CSVStram."""
         # cache file_config so we dont need to go iterating the config list again later
         self.file_config = kwargs.pop("file_config")
+        self.stream_schema = None
         super().__init__(*args, **kwargs)
 
     def get_records(self, context: Context | None) -> t.Iterable[dict]:
@@ -126,8 +127,13 @@ class CSVStream(Stream):
         """Return dictionary of record schema.
 
         Dynamically detect the json schema for the stream.
-        This is evaluated prior to any records being retrieved.
+
+        This property is accessed multiple times for each record
+        so it's important to cache the schema.
         """
+        if self.stream_schema:
+            return self.stream_schema
+
         properties: list[th.Property] = []
         self.primary_keys = self.file_config.get("keys", [])
 
@@ -156,4 +162,5 @@ class CSVStream(Stream):
         # Cache header for future use
         self.header = header
 
-        return th.PropertiesList(*properties).to_dict()
+        self.stream_schema = th.PropertiesList(*properties).to_dict()
+        return self.stream_schema

--- a/tap_csv/client.py
+++ b/tap_csv/client.py
@@ -131,7 +131,6 @@ class CSVStream(Stream):
         This property is accessed multiple times for each record
         so it's important to cache the result.
         """
-
         properties: list[th.Property] = []
         self.primary_keys = self.file_config.get("keys", [])
 


### PR DESCRIPTION
The stream's `schema` property is accessed multiple times for each record (see `Stream._generate_record_messages()` for instance). Since the schema should be static this change caches it, resulting in a significant performance improvement.

Testing with a sample 2,000,000 row dataset (`people-2000000` from https://github.com/datablist/sample-csv-files) reduced the read time from 441 seconds to 48 seconds; about a 10x improvement in throughput.
